### PR TITLE
Remove incorrect entry points

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,33 +11,8 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . -vv"
-  entry_points:
-    - hr = spacy_lookups_data:hr
-    - pt = spacy_lookups_data:pt
-    - sv = spacy_lookups_data:sv
-    - da = spacy_lookups_data:da
-    - ca = spacy_lookups_data:ca
-    - es = spacy_lookups_data:es
-    - fr = spacy_lookups_data:fr
-    - nb = spacy_lookups_data:nb
-    - tr = spacy_lookups_data:tr
-    - de = spacy_lookups_data:de
-    - it = spacy_lookups_data:it
-    - lt = spacy_lookups_data:lt
-    - nl = spacy_lookups_data:nl
-    - ro = spacy_lookups_data:ro
-    - sr = spacy_lookups_data:sr
-    - id = spacy_lookups_data:id_
-    - hu = spacy_lookups_data:hu
-    - fa = spacy_lookups_data:fa
-    - en = spacy_lookups_data:en
-    - el = spacy_lookups_data:el
-    - bn = spacy_lookups_data:bn
-    - tl = spacy_lookups_data:tl
-    - ur = spacy_lookups_data:ur
-
 
 requirements:
   host:


### PR DESCRIPTION
In conda, the `entry-points` block is somewhat misnamed: it specifies *console script entry-points*, not just plugin registries like we want. This means our package was installing scripts for `tr`, `hu`, etc. Lucky we didn't have an `ls` language yet...

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
